### PR TITLE
Use a electron version that uses a Chrome version that supports CSS `has` pseudoselectors and compiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "d3-force": "3.0.0",
         "diff": "5.0.0",
         "dompurify": "2.4.0",
-        "electron": "20.3.8",
+        "electron": "21.4.1",
         "electron-dl": "3.3.0",
         "fs": "0.0.1-security",
         "fs-extra": "9.1.0",

--- a/resources/package.json
+++ b/resources/package.json
@@ -51,7 +51,7 @@
     "@electron-forge/maker-squirrel": "^6.0.4",
     "@electron-forge/maker-zip": "^6.0.4",
     "@electron/rebuild": "3.2.10",
-    "electron": "20.3.8",
+    "electron": "21.4.1",
     "electron-builder": "^22.11.7",
     "electron-forge-maker-appimage": "https://github.com/logseq/electron-forge-maker-appimage.git"
   },

--- a/static/yarn.lock
+++ b/static/yarn.lock
@@ -2092,6 +2092,15 @@ electron@*, electron@20.3.8:
     "@types/node" "^16.11.26"
     extract-zip "^2.0.1"
 
+electron@21.4.1:
+  version "21.4.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-21.4.1.tgz#e45dcb9c5ff7b42157a5ac535fb5fc2fcd67f9a9"
+  integrity sha512-uhFf3vpE6th6X2E1NSIy1+dWVeS9gb7W8EWd/cn5MacEiv4aVY3gtypaglTaVhYPfnJfcD+v3Ql6gGvx4Efh6A==
+  dependencies:
+    "@electron/get" "^1.14.1"
+    "@types/node" "^16.11.26"
+    extract-zip "^2.0.1"
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,10 +2516,10 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
-electron@20.3.8:
-  version "20.3.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-20.3.8.tgz#94a4b2bb89a3e6bbeb824365cfd0f65658bc1a2c"
-  integrity sha512-P93ZWoJjXEVwsjUJ4q6640KZ4+rmWMZ9O5IB1eq/L9S52ZYsXo0o82afpPXq3j8vpneY0N5J62hgRzC1ZKzYmw==
+electron@21.4.1:
+  version "21.4.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-21.4.1.tgz#e45dcb9c5ff7b42157a5ac535fb5fc2fcd67f9a9"
+  integrity sha512-uhFf3vpE6th6X2E1NSIy1+dWVeS9gb7W8EWd/cn5MacEiv4aVY3gtypaglTaVhYPfnJfcD+v3Ql6gGvx4Efh6A==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
I'm leaving this here mainly as a future reference for myself.

`has:` pseudo selectors are really cool for creating custom block styles based on the contents of such blocks, such as tags. Unfortunately, current versions of logseq use Chrome 104, which doesn't support `has:`. I've updated `electron` to 21.4.1, which uses Chrome 106 and does support `has:`. Before that, I tried the bleeding edge v23.1.0, but `electron-forge` failed with a `node-abi` version mismatch error while compiling (`yarn release-electron` from logseq repo's root dir).

Some examples of rules that can be used, i.e color all blocks tagged with `:project:` differently (inspired by https://discuss.logseq.com/t/block-background-color-setting-specific/8980):

```css
div:not(.initial) > div > div > div > [data-refs-self*='["project"]'] {
   --ls-selection-background-color: #EBCB8B;
   --ls-block-highlight-color: #EBCB8B;
    padding: 8px 0;
    border-radius: 5px;
    border-left: 4px solid #88C0D0;
    background-color: #D8DEE9;
    transform: translateX(-4px);
}

div:has( > span.inline > span.block-tags > a[data-ref='project']) {
    --ls-selection-background-color: #EBCB8B;
   --ls-block-highlight-color: #EBCB8B;
    padding: 8px 0;
    border-radius: 5px;
    border-left: 4px solid #88C0D0;
    background-color: #D8DEE9;
    transform: translateX(-4px);
}
```
